### PR TITLE
Remove import

### DIFF
--- a/select_thoth_integration.py
+++ b/select_thoth_integration.py
@@ -21,11 +21,10 @@ import json
 import os
 import logging
 
-from thoth.workflow_helpers.utils import retrieve_adviser_document
 from thoth.workflow_helpers.trigger_finished_webhook import trigger_finished_webhook
 from thoth.workflow_helpers.configuration import Configuration
 
-from thoth.common.enums import ThothAdviserIntegrationEnum
+from thoth.common import ThothAdviserIntegrationEnum
 
 _LOGGER = logging.getLogger("thoth.select_thoth_integration")
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

@KPostOffice 
```
{"name": "thoth.common", "levelname": "WARNING", "module": "logging", "lineno": 317, "funcname": "init_logging", "created": 1591042186.007702, "asctime": "2020-06-01 20:09:46,007", "msecs": 7.702112197875977, "relative_created": 1816.1468505859375, "process": 1, "message": "Logging to a Sentry instance is turned off"}
Traceback (most recent call last):
  File "select_thoth_integration.py", line 24, in <module>
    from thoth.workflow_helpers.utils import retrieve_adviser_document
ModuleNotFoundError: No module named 'thoth.workflow_helpers.utils'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Remove import

## Required
New patch release of workflow-helpers is required after merging.