### PR TITLE
Add message content for service name and version sending Kafka Messages

### DIFF
--- a/parse_solved_package.py
+++ b/parse_solved_package.py
@@ -31,6 +31,9 @@ GRAPH.connect()
 ADVISER_STORE = AdvisersResultsStore()
 ADVISER_STORE.connect()
 
+component_name = os.environ["THOTH_COMPONENT_NAME"]
+service_version = os.environ["THOTH_SERVICE_NAME"]
+
 _LOGGER = logging.getLogger("thoth.parse_solved_package")
 
 
@@ -116,6 +119,8 @@ def parse_solved_package() -> None:
 
             # 4. Save adviser_id_message inputs
             message_input = {
+                "component_name": {"type": "str", "value": component_name},
+                "service_version": {"type": "str", "value": service_version},
                 "re_run_adviser_id": {"type": "str", "value": adviser_id},
                 "application_stack": {"type": "Dict[Any, Any]", "value": application_stack},
                 "recommendation_type": {"type": "str", "value": recommendation_type},

--- a/parse_solved_package.py
+++ b/parse_solved_package.py
@@ -31,8 +31,8 @@ GRAPH.connect()
 ADVISER_STORE = AdvisersResultsStore()
 ADVISER_STORE.connect()
 
-component_name = os.environ["THOTH_COMPONENT_NAME"]
-service_version = os.environ["THOTH_SERVICE_NAME"]
+component_name = os.environ["THOTH_MESSAGING_COMPONENT_NAME"]
+service_version = os.environ["THOTH_MESSAGING_SERVICE_NAME"]
 
 _LOGGER = logging.getLogger("thoth.parse_solved_package")
 

--- a/parse_solved_package.py
+++ b/parse_solved_package.py
@@ -25,6 +25,8 @@ from typing import List
 from thoth.storages import GraphDatabase
 from thoth.storages import AdvisersResultsStore
 
+from thoth.workflow_helpers.common import retrieve_solver_service_version
+
 GRAPH = GraphDatabase()
 GRAPH.connect()
 
@@ -32,7 +34,7 @@ ADVISER_STORE = AdvisersResultsStore()
 ADVISER_STORE.connect()
 
 component_name = os.environ["THOTH_MESSAGING_COMPONENT_NAME"]
-service_version = os.environ["THOTH_MESSAGING_SERVICE_NAME"]
+document_path = os.environ["THOTH_SOLVER_DOCUMENT_PATH"]
 
 _LOGGER = logging.getLogger("thoth.parse_solved_package")
 
@@ -72,6 +74,8 @@ def parse_solved_package() -> None:
 
     solver_indexes = os.environ["THOTH_SOLVER_INDEXES"]
     indexes = solver_indexes.split(",")
+
+    service_version = retrieve_solver_service_version(document_path)
 
     # 1. Retrieve adviser ids for specific thoth_integrations with need_re_run == True
     unsolved_per_adviser_runs = GRAPH.get_unsolved_python_packages_all_per_adviser_run(source_type="github_app")

--- a/parse_solver_inputs.py
+++ b/parse_solver_inputs.py
@@ -21,8 +21,10 @@ import os
 import logging
 import json
 
+from thoth.workflow_helpers.common import retrieve_solver_service_version
+
 component_name = os.environ["THOTH_MESSAGING_COMPONENT_NAME"]
-service_version = os.environ["THOTH_MESSAGING_SERVICE_NAME"]
+document_path = os.environ["THOTH_SOLVER_DOCUMENT_PATH"]
 
 _LOGGER = logging.getLogger("thoth.parse_solver_inputs")
 
@@ -36,6 +38,8 @@ def parse_solver_inputs() -> None:
 
     solver_indexes = os.environ["THOTH_SOLVER_INDEXES"]
     indexes = solver_indexes.split(",")
+
+    service_version = retrieve_solver_service_version(document_path)
 
     output_messages = []
 

--- a/parse_solver_inputs.py
+++ b/parse_solver_inputs.py
@@ -21,6 +21,8 @@ import os
 import logging
 import json
 
+component_name = os.environ["THOTH_COMPONENT_NAME"]
+service_version = os.environ["THOTH_SERVICE_NAME"]
 
 _LOGGER = logging.getLogger("thoth.parse_solver_inputs")
 
@@ -40,6 +42,8 @@ def parse_solver_inputs() -> None:
     for index_url in indexes:
 
         message_input = {
+            "component_name": {"type": "str", "value": component_name},
+            "service_version": {"type": "str", "value": service_version},
             "package_name": {"type": "str", "value": package_inputs[0]},
             "package_version": {"type": "str", "value": package_inputs[1]},
             "index_url": {"type": "str", "value": index_url},

--- a/parse_solver_inputs.py
+++ b/parse_solver_inputs.py
@@ -21,8 +21,8 @@ import os
 import logging
 import json
 
-component_name = os.environ["THOTH_COMPONENT_NAME"]
-service_version = os.environ["THOTH_SERVICE_NAME"]
+component_name = os.environ["THOTH_MESSAGING_COMPONENT_NAME"]
+service_version = os.environ["THOTH_MESSAGING_SERVICE_NAME"]
 
 _LOGGER = logging.getLogger("thoth.parse_solver_inputs")
 

--- a/thoth/workflow_helpers/common.py
+++ b/thoth/workflow_helpers/common.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# thoth-workflow-helpers
+# Copyright(C) 2020 Francesco Murdaca
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Common methods for all workflow helpers."""
+
+import logging
+import os
+import json
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def retrieve_solver_service_version(document_path: str):
+    """Retrieve solver service version from solver document."""
+    _LOGGER.info("Loading document from a local file: %r", document_path)
+    with open(document_path, "r") as document_file:
+        solver_document = json.loads(document_file.read())
+
+    solver_report_metadata = solver_document["metadata"]
+
+    return solver_report_metadata["analyzer_version"]
+
+

--- a/thoth/workflow_helpers/common.py
+++ b/thoth/workflow_helpers/common.py
@@ -18,7 +18,6 @@
 """Common methods for all workflow helpers."""
 
 import logging
-import os
 import json
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,5 +32,3 @@ def retrieve_solver_service_version(document_path: str):
     solver_report_metadata = solver_document["metadata"]
 
     return solver_report_metadata["analyzer_version"]
-
-


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/messaging/issues/230

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add component name and service version to the message to know which component is sending messages