### PR TITLE
update base image to be used for build.

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -2,7 +2,7 @@ check:
   - thoth-precommit
   - thoth-build
 build:
-  base-image: "quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.0"
+  base-image: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0"
   build-stratergy: "Source"
   registry: "quay.io"
   registry-org: "thoth-station"


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: https://github.com/AICoE/aicoe-ci/issues/57

## This introduces a breaking change

- [x] No

## This Pull Request implements

Updated base image in aicoe-ci.yaml to use python3.6 based thoth ubi image.

## Description

update base image to be used for the build.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
