### PR TITLE
Change name because overwrite Argo default

### DIFF
--- a/select_thoth_integration.py
+++ b/select_thoth_integration.py
@@ -43,7 +43,7 @@ def trigger_integration_workflow() -> None:
         f.write(source_type)
 
     if source_type == ThothAdviserIntegrationEnum.KEBECHET.name:
-        with open("/mnt/workdir/origin", "w") as f:
+        with open("/mnt/workdir/metadata_origin", "w") as f:
             f.write(metadata["origin"])
 
         with open("/mnt/workdir/git_service", "w") as f:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
STEP                        TEMPLATE                                     PODNAME                      DURATION  MESSAGE
 ✖ adviser-f99425fc         adviser                                                                                                                                                                    
 ├-✔ advise                 advise/advise                                adviser-f99425fc-4093066776  11s                                                                                              
 ├-✖ investigator-producer  investigator-producer/investigator-producer  adviser-f99425fc-3978409058  23s       failed with exit code 2                                                                
 ├-✔ graph-sync-advise(0)   graph-sync/graph-sync                        adviser-f99425fc-1771713038  22s                                                                                              
 ├-⚠ trigger-integration    trigger-integration/trigger-integration      adviser-f99425fc-2630790839  12s       failed to save outputs: open /mainctrfs/mnt/workdir/origin: no such file or directory  
 └- kebechet-run-results             kebechet-run-results/schedule-kebechet                                              omitted: depends condition not met         

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Change file name stored
