### PR TITLE
Store file always to avoid workflow failing

### DIFF
--- a/parse_solved_package.py
+++ b/parse_solved_package.py
@@ -143,10 +143,11 @@ def parse_solved_package() -> None:
                 {"topic_name": "thoth.investigator.adviser-re-run", "message_contents": message_input}
             )
 
+    # 5. Store messages that need to be sent
+    with open(f"/mnt/workdir/adviser_runs_messages.json", "w") as json_file:
+        json.dump(output_messages, json_file)
+
     if output_messages:
-        # 5. Store messages that need to be sent
-        with open(f"/mnt/workdir/adviser_runs_messages.json", "w") as json_file:
-            json.dump(output_messages, json_file)
         _LOGGER.info("Successfully stored file with adviser re run messages!")
 
 

--- a/parse_solver_inputs.py
+++ b/parse_solver_inputs.py
@@ -58,9 +58,10 @@ def parse_solver_inputs() -> None:
 
         output_messages.append({"topic_name": "thoth.solver.solved-package", "message_contents": message_input})
 
+    with open(f"/mnt/workdir/solved_messages.json", "w") as json_file:
+        json.dump(output_messages, json_file)
+
     if output_messages:
-        with open(f"/mnt/workdir/solved_messages.json", "w") as json_file:
-            json.dump(output_messages, json_file)
         _LOGGER.info("Successfully stored file with solved messages!")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
STEP                               TEMPLATE                                   PODNAME                                    DURATION  MESSAGE
 ✖ solver-fedora-32-py37-1578dfb5  solve-and-sync                                                                                                                      
 ├-✔ solverany(0)                  solver-any/solve                           solver-fedora-32-py37-1578dfb5-2537784971  43s                                           
 ├-✔ graph-sync-solverany(0)       graph-sync/graph-sync                      solver-fedora-32-py37-1578dfb5-2182647454  1m                                            
 ├-✖ parse-solved-package          parse-solved-package/parse-solved-package  solver-fedora-32-py37-1578dfb5-65476471    45s       failed with exit code 1             
 ├-✔ parse-solver-inputs           parse-solver-inputs/parse-solver-inputs    solver-fedora-32-py37-1578dfb5-574526462   35s                                           
 ├-✔ send-solved-message           send-messages/send-messages                solver-fedora-32-py37-1578dfb5-2018198733  49s                                           
 └- send-adviser-rerun-messages             send-messages/send-messages                                                                     omitted: depends condition not met  
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Allow storing empty file
