### PR TITLE
add more verbose errors by parsing package index

### DIFF
--- a/thoth/workflow_helpers/exception.py
+++ b/thoth/workflow_helpers/exception.py
@@ -19,3 +19,11 @@
 
 class TriggerFinishedWebhookInputsMissing(Exception):
     """An exception raised if there are inputs missing for Triggering Finished Webhook."""
+
+
+class SourceDistroNotFound(Exception):
+    """An exception is raised if there is no source distro found for a given package."""
+
+
+class VersionDoesNotExist(Exception):
+    """An exception is raised if the requested version does not exist at all."""


### PR DESCRIPTION
## Related Issues and Dependencies

#108 
## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

pip does not offer the best error messages when it fails to get a package, to give more insight into the actual cause we check whether the cause is a missing package version or if the given package version doesn't provide a source distrobution

## Description

Because all package indexes must be compliant with pip they provide links which indicate the type of package distribution, we can infer if it is a source distribution based on the file extension.  We then just check whether there exists a link which ends with `<package_version>.(tar.gz|.zip)` as well as whether that version exists on the index at all.

<!--- Describe your changes in detail -->
