### PR TITLE
store default empty string for other source types

### DIFF
--- a/select_thoth_integration.py
+++ b/select_thoth_integration.py
@@ -53,6 +53,12 @@ def trigger_integration_workflow() -> None:
             git_service = parse.urlsplit(metadata["origin"]).hostname.split(".")[-2]
             f.write(git_service)
 
+    else:
+        with open("/mnt/workdir/metadata_origin", "w") as f:
+            f.write("")
+        with open("/mnt/workdir/git_service", "w") as f:
+            f.write("")
+
     if source_type == ThothAdviserIntegrationEnum.GITHUB_APP.name:
         trigger_finished_webhook(metadata=metadata, document_id=Configuration._THOTH_DOCUMENT_ID)
 


### PR DESCRIPTION
## Related Issues and Dependencies

Related-To: #67 

## This introduces a breaking change

- [x] No


## This Pull Request implements

- save empty string to the metadata_origin.

## Description

store default empty string for other source types
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
