### PR TITLE
Assign datatype in message

### DIFF
--- a/download_py_package.py
+++ b/download_py_package.py
@@ -51,10 +51,6 @@ def download_py_package() -> None:
         if link.string.endswith(f"-{Configuration.PACKAGE_VERSION}.zip") or link.string.endswith(
             f"-{Configuration.PACKAGE_VERSION}.tar.gz"
         ):
-            with open(MESSAGE_LOCATION, "w") as f:
-                f.write("")
-            with open(FAILED_STATUS_FILE, "w") as f:
-                f.write("0")
             break
 
         elif f"-{Configuration.PACKAGE_VERSION}-" in link.string:
@@ -71,10 +67,10 @@ def download_py_package() -> None:
                 {
                     "topic_name": UpdateProvidesSourceDistroMessage.topic_name,
                     "message_contents": {
-                        "package_name": Configuration.PACKAGE_NAME,
-                        "package_version": Configuration.PACKAGE_VERSION,
-                        "index_url": Configuration.PACKAGE_INDEX,
-                        "value": False,
+                        "package_name": {"type": "str", "value": Configuration.PACKAGE_NAME},
+                        "package_version": {"type": "str", "value": Configuration.PACKAGE_VERSION},
+                        "index_url": {"type": "str", "value": Configuration.PACKAGE_INDEX},
+                        "value": {"type": "bool", "value": False},
                     },
                 }
             ]
@@ -95,9 +91,9 @@ def download_py_package() -> None:
                 {
                     "topic_name": MissingVersionMessage.topic_name,
                     "message_contents": {
-                        "package_name": Configuration.PACKAGE_NAME,
-                        "package_version": Configuration.PACKAGE_VERSION,
-                        "index_url": Configuration.PACKAGE_INDEX,
+                        "package_name": {"type": "str", "value": Configuration.PACKAGE_NAME},
+                        "package_version": {"type": "str", "value": Configuration.PACKAGE_VERSION},
+                        "index_url": {"type": "str", "value": Configuration.PACKAGE_INDEX},
                     },
                 }
             ]
@@ -108,6 +104,11 @@ def download_py_package() -> None:
                 f.write("1")
 
             return
+
+    with open(MESSAGE_LOCATION, "w") as f:
+        f.write("")
+    with open(FAILED_STATUS_FILE, "w") as f:
+        f.write("0")
 
     command = (
         f"pip download --no-binary=:all: --no-deps -d {WORKDIR} -i {Configuration.PACKAGE_INDEX} "

--- a/download_py_package.py
+++ b/download_py_package.py
@@ -116,15 +116,15 @@ def download_py_package() -> None:
     )
     run_command(command)
 
-    for f in os.listdir(WORKDIR):
-        if f.endswith(".tar.gz"):
-            full_path = os.path.join(WORKDIR, f)
+    for file_ in os.listdir(WORKDIR):
+        if file_.endswith(".tar.gz"):
+            full_path = os.path.join(WORKDIR, file_)
             tar = tarfile.open(full_path, "r:gz")
             tar.extractall(os.path.join(WORKDIR, "package"))
             break
-        elif f.endswith(".zip"):
-            full_path = os.path.join(WORKDIR, f)
-            with zipfile.ZipFile(os.path.join(WORKDIR, f), "r") as zip_ref:
+        elif file_.endswith(".zip"):
+            full_path = os.path.join(WORKDIR, file_)
+            with zipfile.ZipFile(os.path.join(WORKDIR, file_), "r") as zip_ref:
                 zip_ref.extractall(os.path.join(WORKDIR, "package"))
             break
     else:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-To: https://github.com/thoth-station/thoth-application/issues/507

```
STEP                                   TEMPLATE                           PODNAME                                 DURATION  MESSAGE
 ✖ security-indicator-e726468f         security-indicators                                                                                                 
 ├-✔ download-package                  download-package/download-package  security-indicator-e726468f-1919884269  23s                                      
 ├-○ aggregator                        aggregator/aggregator                                                                when '1 == 0' evaluated false  
 ├-○ bandit                            bandit/bandit-from-dir                                                               when '1 == 0' evaluated false  
 ├-○ cloc                              cloc/cloc-from-dir                                                                   when '1 == 0' evaluated false  
 ├-○ graph-sync-security-indicators    graph-sync/graph-sync                                                                when '1 == 0' evaluated false  
 └-✖ send-messages                     send-messages/send-messages        security-indicator-e726468f-2856959561  30s       failed with exit code 1        
                                                                                                                                                                    
 ● security-indicator-e726468f.onExit  exit-handler                                                                                                        
 └---◷ delete-pvc                      delete-pvc                         security-indicator-e726468f-3905629212  5s        ContainerCreating              
^C
 ✘ fmurdaca@pc-7  ~/work/aicoe/common   master ●  
 ✘ fmurdaca@pc-7  ~/work/aicoe/common   master ●  argo logs security-indicator-e726468f
security-indicator-e726468f-1919884269: 2020-10-02T08:45:46.719298072Z {"name": "thoth.common", "levelname": "WARNING", "module": "logging", "lineno": 344, "funcname": "init_logging", "created": 1601628346.7188299, "asctime": "2020-10-02 08:45:46,718", "msecs": 718.829870223999, "relative_created": 6797.314405441284, "process": 1, "message": "Logging to a Sentry instance is turned off"}
security-indicator-e726468f-1919884269: 2020-10-02T08:45:48.133666599Z {"name": "thoth.download_package", "levelname": "WARNING", "module": "download_py_package", "lineno": 66, "funcname": "download_py_package", "created": 1601628348.1331735, "asctime": "2020-10-02 08:45:48,133", "msecs": 133.17346572875977, "relative_created": 8211.658000946045, "process": 1, "message": "version 0.0.8for package bentomlfrom https://pypi.org/simple does not provide source distro."}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.166156709Z [2020-10-02 08:46:19,164] [22] [WARNING] Logging to a Sentry instance is turned off 
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.166379176Z {"name": "thoth.common", "levelname": "WARNING", "module": "logging", "lineno": 344, "funcname": "init_logging", "created": 1601628379.1640327, "asctime": "2020-10-02 08:46:19,164", "msecs": 164.0326976776123, "relative_created": 4213.315010070801, "process": 22, "message": "Logging to a Sentry instance is turned off"}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self.run(*args, **kwargs)
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     message_dict = {i: m_contents[i]["value"] for i in m_contents}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/src/cli.py", line 159, in messaging
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/src/cli.py", line 159, in <dictcomp>
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     message_dict = {i: m_contents[i]["value"] for i in m_contents}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z TypeError: string indices must be integers
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z Traceback (most recent call last):
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/worker.py", line 273, in execute_from_commandline
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     self.loop.run_until_complete(self._starting_fut)
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/usr/lib64/python3.6/asyncio/base_events.py", line 484, in run_until_complete
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     return future.result()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self._default_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self._actually_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 767, in _actually_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await child.maybe_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 795, in maybe_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self.start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self._default_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self._actually_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 760, in _actually_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self.on_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 1073, in on_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z     await self._fut
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z   File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 598, in execute
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.176504834Z [2020-10-02 08:46:19,167] [22] [ERROR] [^Worker]: Error: TypeError('string indices must be integers',) 
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.177101776Z {"name": "mode.worker", "levelname": "ERROR", "module": "logging", "lineno": 267, "funcname": "log", "created": 1601628379.1671658, "asctime": "2020-10-02 08:46:19,167", "msecs": 167.16575622558594, "relative_created": 4216.448068618774, "process": 22, "message": "[^Worker]: Error: TypeError('string indices must be integers',)\nTraceback (most recent call last):\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/worker.py\", line 273, in execute_from_commandline\n    self.loop.run_until_complete(self._starting_fut)\n  File \"/usr/lib64/python3.6/asyncio/base_events.py\", line 484, in run_until_complete\n    return future.result()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 736, in start\n    await self._default_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 743, in _default_start\n    await self._actually_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 767, in _actually_start\n    await child.maybe_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 795, in maybe_start\n    await self.start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 736, in start\n    await self._default_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 743, in _default_start\n    await self._actually_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 760, in _actually_start\n    await self.on_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 1073, in on_start\n    await self._fut\n  File \"/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py\", line 598, in execute\n    await self.run(*args, **kwargs)\n  File \"/opt/app-root/src/cli.py\", line 159, in messaging\n    message_dict = {i: m_contents[i][\"value\"] for i in m_contents}\n  File \"/opt/app-root/src/cli.py\", line 159, in <dictcomp>\n    message_dict = {i: m_contents[i][\"value\"] for i in m_contents}\nTypeError: string indices must be integers"}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 839, in stop
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     message_dict = {i: m_contents[i]["value"] for i in m_contents}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/src/cli.py", line 159, in <dictcomp>
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     message_dict = {i: m_contents[i]["value"] for i in m_contents}
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z TypeError: string indices must be integers
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z [2020-10-02 08:46:19,177] [22] [ERROR] [^Worker]: Error while stopping child <messaging: stopping >: TypeError('string indices must be integers',) 
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z Traceback (most recent call last):
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 863, in _default_stop_children
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await asyncio.shield(child.stop())
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/src/cli.py", line 159, in messaging
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self.on_stop()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 1084, in on_stop
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     fut.result()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/worker.py", line 273, in execute_from_commandline
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     self.loop.run_until_complete(self._starting_fut)
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/usr/lib64/python3.6/asyncio/base_events.py", line 484, in run_until_complete
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     return future.result()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self._default_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self._fut
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 767, in _actually_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self.run(*args, **kwargs)
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 795, in maybe_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self.start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self._default_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self._actually_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 760, in _actually_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self.on_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 1073, in on_start
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await self._actually_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z   File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 598, in execute
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180367044Z     await child.maybe_start()
security-indicator-e726468f-2856959561: 2020-10-02T08:46:19.180823464Z {"name": "mode.worker", "levelname": "ERROR", "module": "logging", "lineno": 267, "funcname": "log", "created": 1601628379.1776078, "asctime": "2020-10-02 08:46:19,177", "msecs": 177.60777473449707, "relative_created": 4226.890087127686, "process": 22, "message": "[^Worker]: Error while stopping child <messaging: stopping >: TypeError('string indices must be integers',)\nTraceback (most recent call last):\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 863, in _default_stop_children\n    await asyncio.shield(child.stop())\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 839, in stop\n    await self.on_stop()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 1084, in on_stop\n    fut.result()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/worker.py\", line 273, in execute_from_commandline\n    self.loop.run_until_complete(self._starting_fut)\n  File \"/usr/lib64/python3.6/asyncio/base_events.py\", line 484, in run_until_complete\n    return future.result()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 736, in start\n    await self._default_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 743, in _default_start\n    await self._actually_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 767, in _actually_start\n    await child.maybe_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 795, in maybe_start\n    await self.start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 736, in start\n    await self._default_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 743, in _default_start\n    await self._actually_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 760, in _actually_start\n    await self.on_start()\n  File \"/opt/app-root/lib/python3.6/site-packages/mode/services.py\", line 1073, in on_start\n    await self._fut\n  File \"/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py\", line 598, in execute\n    await self.run(*args, **kwargs)\n  File \"/opt/app-root/src/cli.py\", line 159, in messaging\n    message_dict = {i: m_contents[i][\"value\"] for i in m_contents}\n  File \"/opt/app-root/src/cli.py\", line 159, in <dictcomp>\n    message_dict = {i: m_contents[i][\"value\"] for i in m_contents}\nTypeError: string indices must be integers"}
security-indicator-e726468f-3905629212: 2020-10-02T08:46:29.35569823Z time="2020-10-02T08:46:29.355Z" level=info msg="Starting Workflow Executor" version=v2.11.0
security-indicator-e726468f-3905629212: 2020-10-02T08:46:29.359109794Z time="2020-10-02T08:46:29.358Z" level=info msg="Creating a K8sAPI executor"
security-indicator-e726468f-3905629212: 2020-10-02T08:46:29.359109794Z time="2020-10-02T08:46:29.358Z" level=info msg="Executor (version: v2.11.0, build_date: 2020-09-17T22:51:06Z) initialized (pod: thoth-test-core/security-indicator-e726468f-3905629212) with template:\n{\"name\":\"delete-pvc\",\"arguments\":{},\"inputs\":{},\"outputs\":{},\"metadata\":{},\"resource\":{\"action\":\"delete\",\"manifest\":\"apiVersion: v1\\nkind: PersistentVolumeClaim\\nmetadata:\\n  name: security-indicator-e726468f-workdir\\n\"}}"
security-indicator-e726468f-3905629212: 2020-10-02T08:46:29.359109794Z time="2020-10-02T08:46:29.359Z" level=info msg="Loading manifest to /tmp/manifest.yaml"
security-indicator-e726468f-3905629212: 2020-10-02T08:46:29.359564181Z time="2020-10-02T08:46:29.359Z" level=info msg="kubectl delete --ignore-not-found -f /tmp/manifest.yaml -o name"
```