### PR TITLE
Fix sourcetpye

### DIFF
--- a/qeb_thamos_advise.py
+++ b/qeb_thamos_advise.py
@@ -131,7 +131,7 @@ def qeb_hwt_thamos_advise() -> None:
         "github_installation_id": {"type": "int", "value": int(Configuration._GITHUB_INSTALLATION_ID)},
         "github_base_repo_url": {"type": "str", "value": Configuration._GITHUB_BASE_REPO_URL},
         "origin": {"type": "str", "value": Configuration._ORIGIN},
-        "source_type": {"type": "str", "value": ThothAdviserIntegrationEnum.GITHUB_APP},
+        "source_type": {"type": "str", "value": ThothAdviserIntegrationEnum.GITHUB_APP.name},
     }
 
     # We store the message to put in the output file here.


### PR DESCRIPTION
## Related Issues and Dependencies
Workflow fails stating - 
```
32", "msecs": 32.85336494445801, "relative_created": 8298.675298690796, "process": 1, "message": "Logging to a Sentry instance is turned off"}
qeb-hwt-f78ed1bc-731065535: Traceback (most recent call last):
qeb-hwt-f78ed1bc-731065535:   File "qeb_thamos_advise.py", line 149, in <module>
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/__init__.py", line 179, in dump
qeb-hwt-f78ed1bc-731065535:     qeb_hwt_thamos_advise()
qeb-hwt-f78ed1bc-731065535:   File "qeb_thamos_advise.py", line 142, in qeb_hwt_thamos_advise
qeb-hwt-f78ed1bc-731065535:     json.dump(message_output, json_file)
qeb-hwt-f78ed1bc-731065535:     for chunk in iterable:
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 428, in _iterencode
qeb-hwt-f78ed1bc-731065535:     yield from _iterencode_list(o, _current_indent_level)
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 325, in _iterencode_list
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
qeb-hwt-f78ed1bc-731065535:     yield from chunks
qeb-hwt-f78ed1bc-731065535:     yield from chunks
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
qeb-hwt-f78ed1bc-731065535:     yield from chunks
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
qeb-hwt-f78ed1bc-731065535:     yield from chunks
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 437, in _iterencode
qeb-hwt-f78ed1bc-731065535:     o = _default(o)
qeb-hwt-f78ed1bc-731065535:   File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
qeb-hwt-f78ed1bc-731065535:     o.__class__.__name__)
qeb-hwt-f78ed1bc-731065535: TypeError: Object of type 'ThothAdviserIntegrationEnum' is not JSON serializable
```
