### PR TITLE
get inspection info from env

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -22,4 +22,6 @@ elif [ "$THOTH_WORKFLOW_TASK" = "parse_solver_output" ]; then
     exec python3 parse_solver_output.py
 elif [ "$THOTH_WORKFLOW_TASK" = "parse_adviser_output" ]; then
     exec python3 parse_adviser_output.py
+elif [ "$THOTH_WORKFLOW_TASK" = "create_inspection_complete_message" ]; then
+    exec python3 create_inspection_complete_message.py
 fi

--- a/create_inspection_complete_message.py
+++ b/create_inspection_complete_message.py
@@ -35,10 +35,18 @@ def create_inspection_complete_message():
         "deployment_name": {"type": "str", "value": deployment_name},
     }
 
-    messages = [{"topic_name": "thoth.inspection-completed", "message_contents": message_contents}]
+    message = {"topic_name": "thoth.inspection-completed", "message_contents": message_contents}
 
-    with open(MSG_FILE, "w") as f:
-        json.dump(messages, f)
+    with open(MSG_FILE, "rw") as f:
+        if os.stat(f).st_size != 0:
+            all_messages: list = json.load(f)
+            if type(all_messages) != list:
+                raise TypeError(f"Message file must be a list of messages. Got type {type(all_messages)}")
+            all_messages.append(message)
+        else:
+            all_messages = [message]
+
+        json.dump(all_messages, f)
 
 
 if __name__ == "__main__":

--- a/create_inspection_complete_message.py
+++ b/create_inspection_complete_message.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# workflow-helpers
+# Copyright(C) 2020 Kevin Postlethwait
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""This task creates a message file to be used by messaging cli in a workflow."""
+
+import os
+import json
+
+MSG_FILE = "/mnt/workdir/messages_to_be_sent.json"
+
+
+def create_inspection_complete_message():
+    """Create message file (InspectionCompleteMessage) to be sent by thoth-messaging cli."""
+    inspection_id = os.getenv("THOTH_AMUN_INSPECTION_ID")
+    amun_api_url = os.getenv("THOTH_AMUN_API_URL")
+    deployment_name = os.getenv("THOTH_DEPLOYMENT_NAME")
+
+    message_contents = {
+        "inspection_id": {"type": "str", "value": inspection_id},
+        "amun_api_url": {"type": "str", "value": amun_api_url},
+        "deployment_name": {"type": "str", "value": deployment_name},
+    }
+
+    messages = [{"topic_name": "thoth.inspection-completed", "message_contents": message_contents}]
+
+    with open(MSG_FILE, "w") as f:
+        json.dump(messages, f)
+
+
+if __name__ == "__main__":
+    create_inspection_complete_message()


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/issues/398

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Grab contents from env and put them into a file. I am not sure if this was what was intended by the issue, if there is some way to get these values from inspection output it would be better to parse that.