### PR TITLE
Always store file to avoid error in Argo

### DIFF
--- a/parse_adviser_output.py
+++ b/parse_adviser_output.py
@@ -28,7 +28,7 @@ from thoth.common import OpenShift
 
 from thoth.workflow_helpers import __service_version__
 
-from thoth.workflow_helpers.common import store_message
+from thoth.workflow_helpers.common import store_messages
 
 _LOGGER = logging.getLogger("thoth.parse_adviser_output")
 _LOGGER.info("Thoth workflow-helpers task: parse_adviser_output v%s", __service_version__)
@@ -109,7 +109,7 @@ def parse_adviser_output() -> None:
         )
 
     # Store message to file that need to be sent.
-    store_message(output_messages)
+    store_messages(output_messages)
 
 
 if __name__ == "__main__":

--- a/parse_adviser_output.py
+++ b/parse_adviser_output.py
@@ -28,6 +28,8 @@ from thoth.common import OpenShift
 
 from thoth.workflow_helpers import __service_version__
 
+from thoth.workflow_helpers.common import store_message
+
 _LOGGER = logging.getLogger("thoth.parse_adviser_output")
 _LOGGER.info("Thoth workflow-helpers task: parse_adviser_output v%s", __service_version__)
 
@@ -107,11 +109,7 @@ def parse_adviser_output() -> None:
         )
 
     # Store message to file that need to be sent.
-    with open(f"/mnt/workdir/messages_to_be_sent.json", "w") as json_file:
-        json.dump(output_messages, json_file)
-
-    if output_messages:
-        _LOGGER.info(f"Successfully stored file with messages to be sent!: {output_messages}")
+    store_message(output_messages)
 
 
 if __name__ == "__main__":

--- a/parse_solver_output.py
+++ b/parse_solver_output.py
@@ -26,7 +26,7 @@ from thoth.storages import AdvisersResultsStore
 from thoth.storages.graph.enums import ThothAdviserIntegrationEnum
 
 from thoth.workflow_helpers.common import retrieve_solver_document
-from thoth.workflow_helpers.common import store_message
+from thoth.workflow_helpers.common import store_messages
 from thoth.workflow_helpers import __service_version__
 
 GRAPH = GraphDatabase()
@@ -156,7 +156,7 @@ def parse_solver_output() -> None:
                 )
 
     # 5. Store messages that need to be sent
-    store_message(output_messages)
+    store_messages(output_messages)
 
 
 if __name__ == "__main__":

--- a/parse_solver_output.py
+++ b/parse_solver_output.py
@@ -19,7 +19,6 @@
 
 import os
 import logging
-import json
 
 from typing import List
 from thoth.storages import GraphDatabase
@@ -27,6 +26,7 @@ from thoth.storages import AdvisersResultsStore
 from thoth.storages.graph.enums import ThothAdviserIntegrationEnum
 
 from thoth.workflow_helpers.common import retrieve_solver_document
+from thoth.workflow_helpers.common import store_message
 from thoth.workflow_helpers import __service_version__
 
 GRAPH = GraphDatabase()
@@ -156,11 +156,7 @@ def parse_solver_output() -> None:
                 )
 
     # 5. Store messages that need to be sent
-    with open(f"/mnt/workdir/messages_to_be_sent.json", "w") as json_file:
-        json.dump(output_messages, json_file)
-
-    if output_messages:
-        _LOGGER.info(f"Successfully stored file with messages to be sent!: {output_messages}")
+    store_message(output_messages)
 
 
 if __name__ == "__main__":

--- a/qeb_thamos_advise.py
+++ b/qeb_thamos_advise.py
@@ -31,7 +31,7 @@ from thoth.common.enums import ThothAdviserIntegrationEnum
 from thoth.common import OpenShift
 
 from thoth.workflow_helpers.trigger_finished_webhook import trigger_finished_webhook
-from thoth.workflow_helpers.common import store_message
+from thoth.workflow_helpers.common import store_messages
 from thoth.workflow_helpers.configuration import Configuration
 from thoth.workflow_helpers import __service_version__
 
@@ -96,7 +96,7 @@ def qeb_hwt_thamos_advise() -> None:
 
     if not thoth_yaml_config.config_file_exists():
         exception_message = _create_message_config_file_error(no_file=True)
-        store_message(output_messages)
+        store_messages(output_messages)
         trigger_finished_webhook(exception_message=exception_message, has_error=True, error_type="MissingThothYamlFile")
         return
 
@@ -124,7 +124,7 @@ def qeb_hwt_thamos_advise() -> None:
     except Exception as exception:
         _LOGGER.debug(json.loads(exception.body)["error"])  # type: ignore
         exception_message = json.loads(exception.body)["error"]  # type: ignore
-        store_message(output_messages)
+        store_messages(output_messages)
         trigger_finished_webhook(exception_message=exception_message, has_error=True)
         return
 
@@ -146,7 +146,7 @@ def qeb_hwt_thamos_advise() -> None:
     # We store the message to put in the output file here.
     output_messages = [{"topic_name": "thoth.adviser-trigger", "message_contents": message_input}]
 
-    store_message(output_messages)
+    store_messages(output_messages)
 
 
 if __name__ == "__main__":

--- a/thoth/workflow_helpers/common.py
+++ b/thoth/workflow_helpers/common.py
@@ -32,8 +32,8 @@ def retrieve_solver_document(document_path: str):
     return solver_document
 
 
-def store_message(output_messages: list):
-    """Store message."""
+def store_messages(output_messages: list):
+    """Store messages."""
     # Store message to file that need to be sent.
     with open(f"/mnt/workdir/messages_to_be_sent.json", "w") as json_file:
         json.dump(output_messages, json_file)

--- a/thoth/workflow_helpers/common.py
+++ b/thoth/workflow_helpers/common.py
@@ -30,3 +30,13 @@ def retrieve_solver_document(document_path: str):
         solver_document = json.loads(document_file.read())
 
     return solver_document
+
+
+def store_message(output_messages: list):
+    """Store message."""
+    # Store message to file that need to be sent.
+    with open(f"/mnt/workdir/messages_to_be_sent.json", "w") as json_file:
+        json.dump(output_messages, json_file)
+
+    if output_messages:
+        _LOGGER.info(f"Successfully stored file with messages to be sent!: {output_messages}")


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Qeb-Hwt in some cases is failing because it cannot identify the file. This happens because we don't provide a default file, even if empty and Argo expects an output of the task.
