### PR TITLE
Add parse provenance check method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ When the unresolved packages are present, it store messages to be sent for
 an [UnresolvedPackageMessage](https://github.com/thoth-station/messaging/blob/a579a480819a9b35123e9002243f4bba6d082929/thoth/messaging/unresolved_package.py#L35),
 so that these packages can be solved using Thoth [Solver](https://github.com/thoth-station/solver) workflow.
 
+## parse_provenance_checker_output.py
+
+```shell
+REPO_PATH=. THOTH_WORKFLOW_TASK=parse_provenance_checker_output ./app.sh
+```
+
+It checks for any unresolved packages in the provenance checker report.
+When the unresolved packages are present, it store messages to be sent for
+an [UnresolvedPackageMessage](https://github.com/thoth-station/messaging/blob/a579a480819a9b35123e9002243f4bba6d082929/thoth/messaging/unresolved_package.py#L35),
+so that these packages can be solved using Thoth [Solver](https://github.com/thoth-station/solver) workflow.
 
 ## kebechet_administrator.py
 

--- a/app.sh
+++ b/app.sh
@@ -22,6 +22,8 @@ elif [ "$THOTH_WORKFLOW_TASK" = "parse_solver_output" ]; then
     exec python3 parse_solver_output.py
 elif [ "$THOTH_WORKFLOW_TASK" = "parse_adviser_output" ]; then
     exec python3 parse_adviser_output.py
+elif [ "$THOTH_WORKFLOW_TASK" = "parse_provenance_checker_output" ]; then
+    exec python3 parse_provenance_checker_output.py
 elif [ "$THOTH_WORKFLOW_TASK" = "create_inspection_complete_message" ]; then
     exec python3 create_inspection_complete_message.py
 elif [ "$THOTH_WORKFLOW_TASK" = "kebechet_administrator" ]; then

--- a/parse_adviser_output.py
+++ b/parse_adviser_output.py
@@ -100,7 +100,7 @@ def parse_adviser_output() -> None:
             "package_name": {"type": "Dict", "value": package_info.name},
             "package_version": {"type": "str", "value": package_info.version},
             "index_url": {"type": "str", "value": package_info.index},
-            "solver": {"type": "int", "value": solver},
+            "solver": {"type": "str", "value": solver},
         }
 
         # We store the message to put in the output file here.

--- a/parse_adviser_output.py
+++ b/parse_adviser_output.py
@@ -28,7 +28,7 @@ from thoth.common import OpenShift
 
 from thoth.workflow_helpers import __service_version__
 
-from thoth.workflow_helpers.common import store_messages, send_metrics
+from thoth.workflow_helpers.common import store_messages
 
 _LOGGER = logging.getLogger("thoth.parse_adviser_output")
 _LOGGER.info("Thoth workflow-helpers task: parse_adviser_output v%s", __service_version__)
@@ -113,5 +113,4 @@ def parse_adviser_output() -> None:
 
 
 if __name__ == "__main__":
-    send_metrics()
     parse_adviser_output()

--- a/parse_provenance_checker_output.py
+++ b/parse_provenance_checker_output.py
@@ -46,7 +46,7 @@ def _parse_provenance_check_report(report: List[Any]) -> List[Dict[str, str]]:
             unresolved_packages.append(
                 {
                     "package_name": package["package_name"],
-                    "package_version": package["package_version"],
+                    "package_version": package["package_version"].lstrip("=="),
                     "index_url": package["source"]["url"],
                 }
             )

--- a/parse_provenance_checker_output.py
+++ b/parse_provenance_checker_output.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from thoth.workflow_helpers import __service_version__
 
-from thoth.workflow_helpers.common import store_messages, send_metrics
+from thoth.workflow_helpers.common import store_messages
 
 _LOGGER = logging.getLogger("thoth.parse_provenance_checker_output")
 _LOGGER.info("Thoth workflow-helpers task: parse_provenance_checker_output v%s", __service_version__)
@@ -108,5 +108,4 @@ def parse_provenance_checker_output() -> None:
 
 
 if __name__ == "__main__":
-    send_metrics()
     parse_provenance_checker_output()

--- a/parse_provenance_checker_output.py
+++ b/parse_provenance_checker_output.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# workflow-helpers
+# Copyright(C) 2020 Francesco Murdaca
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""This script run in a workflow task to parse provenance checker output."""
+
+
+import logging
+import json
+import os
+
+from typing import List, Any, Dict
+from pathlib import Path
+from thoth.python import Pipfile
+from thoth.common import OpenShift
+
+from thoth.workflow_helpers import __service_version__
+
+from thoth.workflow_helpers.common import store_messages, send_metrics
+
+_LOGGER = logging.getLogger("thoth.parse_provenance_checker_output")
+_LOGGER.info("Thoth workflow-helpers task: parse_provenance_checker_output v%s", __service_version__)
+
+__COMPONENT_NAME__ = "provenance-checker"
+
+
+def _parse_provenance_check_report(
+    report: List[Any]
+) -> List[Dict[str, str]]:
+    """Retrieve unsolved packages from provenance checker run."""
+    package_id = "MISSING-PACKAGE"
+
+    unresolved_packages = []
+
+    for package in report:
+        if package["id"] == package_id:
+            unresolved_packages.append(
+                {
+                    "package_name": package["package_name"],
+                    "package_version": package["package_version"],
+                    "index_url": package["source"]["url"]
+                }
+            )
+
+    return unresolved_packages
+
+
+def parse_provenance_checker_output() -> None:
+    """Investigate on unresolved packages in provenance-checker output."""
+    provenance_checker_run_path = Path(os.environ["FILE_PATH"])
+
+    file_found = True
+
+    unresolved_packages = []
+
+    if not provenance_checker_run_path.exists():
+        _LOGGER.warning(f"Cannot find the file on this path: {provenance_checker_run_path}")
+        file_found = False
+
+    if file_found:
+
+        with open(provenance_checker_run_path, "r") as f:
+            content = json.load(f)
+
+        report = content["result"]["report"]
+
+        if report:
+            unresolved_packages = _parse_provenance_check_report(report=report)
+        else:
+            _LOGGER.warning("Report in the document is empty.")
+
+        if not unresolved_packages:
+            _LOGGER.warning("No packages to be solved with priority identified.")
+            unresolved_found = False
+
+        else:
+            _LOGGER.info(f"Identified the following unresolved packages: {unresolved_packages}")
+
+    solver = None  # No solver: all available solvers will be scheduled for unsolved package
+    output_messages = []
+
+    for package in unresolved_packages:
+
+        message_input = {
+            "component_name": {"type": "str", "value": __COMPONENT_NAME__},
+            "service_version": {"type": "str", "value": __service_version__},
+            "package_name": {"type": "Dict", "value": package['package_name']},
+            "package_version": {"type": "str", "value": package['package_version']},
+            "index_url": {"type": "str", "value": package['index_url']},
+            "solver": {"type": "str", "value": solver},
+        }
+
+        # We store the message to put in the output file here.
+        output_messages.append(
+            {"topic_name": "thoth.investigator.unresolved-package", "message_contents": message_input}
+        )
+
+    # Store message to file that need to be sent.
+    store_messages(output_messages)
+
+
+if __name__ == "__main__":
+    send_metrics()
+    parse_provenance_checker_output()

--- a/parse_provenance_checker_output.py
+++ b/parse_provenance_checker_output.py
@@ -24,8 +24,6 @@ import os
 
 from typing import List, Any, Dict
 from pathlib import Path
-from thoth.python import Pipfile
-from thoth.common import OpenShift
 
 from thoth.workflow_helpers import __service_version__
 
@@ -37,9 +35,7 @@ _LOGGER.info("Thoth workflow-helpers task: parse_provenance_checker_output v%s",
 __COMPONENT_NAME__ = "provenance-checker"
 
 
-def _parse_provenance_check_report(
-    report: List[Any]
-) -> List[Dict[str, str]]:
+def _parse_provenance_check_report(report: List[Any]) -> List[Dict[str, str]]:
     """Retrieve unsolved packages from provenance checker run."""
     package_id = "MISSING-PACKAGE"
 
@@ -51,7 +47,7 @@ def _parse_provenance_check_report(
                 {
                     "package_name": package["package_name"],
                     "package_version": package["package_version"],
-                    "index_url": package["source"]["url"]
+                    "index_url": package["source"]["url"],
                 }
             )
 
@@ -84,7 +80,6 @@ def parse_provenance_checker_output() -> None:
 
         if not unresolved_packages:
             _LOGGER.warning("No packages to be solved with priority identified.")
-            unresolved_found = False
 
         else:
             _LOGGER.info(f"Identified the following unresolved packages: {unresolved_packages}")
@@ -97,9 +92,9 @@ def parse_provenance_checker_output() -> None:
         message_input = {
             "component_name": {"type": "str", "value": __COMPONENT_NAME__},
             "service_version": {"type": "str", "value": __service_version__},
-            "package_name": {"type": "Dict", "value": package['package_name']},
-            "package_version": {"type": "str", "value": package['package_version']},
-            "index_url": {"type": "str", "value": package['index_url']},
+            "package_name": {"type": "Dict", "value": package["package_name"]},
+            "package_version": {"type": "str", "value": package["package_version"]},
+            "index_url": {"type": "str", "value": package["index_url"]},
             "solver": {"type": "str", "value": solver},
         }
 


### PR DESCRIPTION
## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/thoth-application/issues/818

## This introduces a breaking change

- [ ] Yes
- [x] No

Example:

```
(workflow-helpers) [fmurdaca@pc-7 10:52:42 ~/work/aicoe/workflow-helpers](add-parse-provenance-check)$ FILE_PATH=./provenance-checker-a69e13582a22625e893400e91a6c199f REPO_PATH=. THOTH_WORKFLOW_TASK=parse_provenance_checker_output ./app.sh

2021-02-01 09:53:37,355 1177873 WARNING  thoth.common:344: Logging to a Sentry instance is turned off
2021-02-01 09:53:37,355 1177873 INFO     thoth.common:366: Logging to rsyslog endpoint is turned off
2021-02-01 09:53:37,364 1177873 INFO     thoth.parse_provenance_checker_output:33: Thoth workflow-helpers task: parse_provenance_checker_output v0.4.0+thamos.1.6.1.common.0.22.0.python.0.11.0analyzer.0.1.8.storages.0.33.0
2021-02-01 09:53:37,364 1177873 WARNING  thoth.workflow_helpers.common:70: THOTH_DEPLOYMENT_NAME env variable is not set.
2021-02-01 09:53:37,364 1177873 WARNING  thoth.workflow_helpers.common:84: PROMETHEUS_PUSHGATEWAY_URL env variable is not set.
2021-02-01 09:53:37,368 1177873 INFO     thoth.parse_provenance_checker_output:85: Identified the following unresolved packages: [{'package_name': 'requests', 'package_version': '==2.25.1', 'index_url': 'https://pypi.org/simple'}, {'package_name': 'thoth-common', 'package_version': '==0.22.0', 'index_url': 'https://pypi.org/simple'}, {'package_name': 'thoth-messaging', 'package_version': '==0.10.1', 'index_url': 'https://pypi.org/simple'}, {'package_name': 'thoth-storages', 'package_version': '==0.33.0', 'index_url': 'https://pypi.org/simple'}, {'package_name': 'pytest', 'package_version': '==6.2.1', 'index_url': 'https://pypi.org/simple'}, {'package_name': 'pytest-cov', 'package_version': '==2.11.1', 'index_url': 'https://pypi.org/simple'}]
```