### PR TITLE
permission must be single char

### DIFF
--- a/create_inspection_complete_message.py
+++ b/create_inspection_complete_message.py
@@ -37,7 +37,7 @@ def create_inspection_complete_message():
 
     message = {"topic_name": InspectionCompletedMessage.base_name, "message_contents": message_contents}
 
-    with open(MSG_FILE, "rw") as f:
+    with open(MSG_FILE, "w") as f:
         if os.stat(f).st_size != 0:
             all_messages: list = json.load(f)
             if type(all_messages) != list:


### PR DESCRIPTION
## Related Issues and Dependencies

```
inspection-test-6fc7ddc8-748641659: Traceback (most recent call last):
inspection-test-6fc7ddc8-748641659:   File "create_inspection_complete_message.py", line 51, in <module>
inspection-test-6fc7ddc8-748641659:   File "create_inspection_complete_message.py", line 38, in create_inspection_complete_message
inspection-test-6fc7ddc8-748641659:     with open(MSG_FILE, "rw") as f:
inspection-test-6fc7ddc8-748641659: ValueError: must have exactly one of create/read/write/append mode
inspection-test-6fc7ddc8-748641659:     create_inspection_complete_message()
```