### PR TITLE
Adjust input to thamos method

### DIFF
--- a/qeb_thamos_advise.py
+++ b/qeb_thamos_advise.py
@@ -122,7 +122,7 @@ def qeb_hwt_thamos_advise() -> None:
     response = advise_using_config(
         pipfile=pipfile_str,
         pipfile_lock=pipfile_lock_str,
-        config=thoth_yaml_config.content,
+        config=json.dumps(thoth_yaml_config.content),
         github_event_type=Configuration._GITHUB_EVENT_TYPE,
         github_check_run_id=Configuration._GITHUB_CHECK_RUN_ID,
         github_installation_id=Configuration._GITHUB_INSTALLATION_ID,

--- a/qeb_thamos_advise.py
+++ b/qeb_thamos_advise.py
@@ -130,6 +130,7 @@ def qeb_hwt_thamos_advise() -> None:
         origin=Configuration._ORIGIN,
         source_type=ThothAdviserIntegrationEnum.GITHUB_APP,
         no_static_analysis=False,
+        src_path=".",
         nowait=True,
     )
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
Traceback (most recent call last):
  File "qeb_thamos_advise.py", line 140, in <module>
    qeb_hwt_thamos_advise()
  File "qeb_thamos_advise.py", line 133, in qeb_hwt_thamos_advise
    nowait=True,
  File "/opt/app-root/lib/python3.6/site-packages/thamos/lib.py", line 343, in advise_using_config
    thoth_config.load_config_from_file(config)
  File "/opt/app-root/lib/python3.6/site-packages/thamos/config.py", line 257, in load_config_from_file
    with open(config_path, "r") as config_file:
TypeError: expected str, bytes or os.PathLike object, not dict
```

## This introduces a breaking change

- [ ] Yes
- [x] No
