### PR TITLE
Fix kebechet administrator scheduling

### DIFF
--- a/kebechet_administrator.py
+++ b/kebechet_administrator.py
@@ -74,7 +74,7 @@ _JUSTIFICATION_MAPPING = {
 all_messages = [m.base_name for m in ALL_MESSAGES]
 
 
-def _handle_solved_message():  # noqa: N803
+def _handle_solved_message(Configuration):  # noqa: N803
     """Handle all the messages for which Kebechet needs to run on if the sovler type matches the os type."""
     solver_string = os.environ["THOTH_SOLVER_NAME"]  # ex - solver-fedora-31-py38
     if not solver_string:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>
```
{"name": "thoth.common", "levelname": "WARNING", "module": "logging", "lineno": 344, "funcname": "init_logging", "created": 1629799877.9963524, "asctime": "2021-08-24 10:11:17,996", "msecs": 996.3524341583252, "relative_created": 6906.395673751831, "process": 1, "message": "Logging to a Sentry instance is turned off"}
Traceback (most recent call last):
  File "kebechet_administrator.py", line 219, in <module>
    run_kebechet_administrator()
  File "kebechet_administrator.py", line 201, in run_kebechet_administrator
    _message_handler[Configuration.MESSAGE_TYPE](Configuration)
TypeError: _handle_solved_message() takes 0 positional arguments but 1 was given
```
