### PR TITLE
updating pre-commit protocol

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -2,7 +2,7 @@ check:
   - thoth-build
 build:
   base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0
-  build-stratergy: Source
+  build-strategy: Source
   registry: quay.io
   registry-org: thoth-station
   registry-project: workflow-helpers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.10
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: trailing-whitespace
@@ -22,7 +22,7 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: 6.1.1
     hooks:
       - id: pydocstyle


### PR DESCRIPTION
Using unencrypted version of the git protocol has been deprecated. Switching to HTTPS for pre-commit repos. Additionaly fixed build-strategy in .aicoe-ci.yaml.

## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/2111